### PR TITLE
Raw retrieval

### DIFF
--- a/src/common/mbeir_retriever.py
+++ b/src/common/mbeir_retriever.py
@@ -259,7 +259,7 @@ def get_raw_retrieved_candidates(queries_path, candidates_path, retrieved_indice
     return retrieved_dict
 
 
-def run_retrieval(config, query_embedder_config):
+def run_retrieval(config, query_embedder_config=None):
     """This script runs retrieval on the faiss index"""
     uniir_dir = config.uniir_dir
     mbeir_data_dir = config.mbeir_data_dir

--- a/src/common/mbeir_retriever.py
+++ b/src/common/mbeir_retriever.py
@@ -7,6 +7,7 @@ import argparse
 from omegaconf import OmegaConf
 from collections import defaultdict
 from datetime import datetime
+import json
 
 import numpy as np
 import csv
@@ -36,7 +37,9 @@ def create_index(config):
     expt_dir_name = config.experiment.path_suffix
 
     idx_cand_pools_config = index_config.cand_pools_config
-    assert idx_cand_pools_config.enable_idx, "Indexing is not enabled for candidate pool"
+    assert (
+        idx_cand_pools_config.enable_idx
+    ), "Indexing is not enabled for candidate pool"
     split_name = "cand_pool"
     cand_pool_name_list = idx_cand_pools_config.cand_pools_name_to_idx
 
@@ -49,10 +52,16 @@ def create_index(config):
         cand_pool_name = cand_pool_name.lower()
 
         embed_data_file = f"mbeir_{cand_pool_name}_{split_name}_embed.npy"
-        embed_data_path = os.path.join(uniir_dir, embed_dir_name, expt_dir_name, split_name, embed_data_file)
+        embed_data_path = os.path.join(
+            uniir_dir, embed_dir_name, expt_dir_name, split_name, embed_data_file
+        )
         embed_data_hashed_id_file = f"mbeir_{cand_pool_name}_{split_name}_ids.npy"
         embed_data_hashed_id_path = os.path.join(
-            uniir_dir, embed_dir_name, expt_dir_name, split_name, embed_data_hashed_id_file
+            uniir_dir,
+            embed_dir_name,
+            expt_dir_name,
+            split_name,
+            embed_data_hashed_id_file,
         )
 
         print(f"Building index for {embed_data_path} and {embed_data_hashed_id_path}")
@@ -72,7 +81,9 @@ def create_index(config):
 
         # Create the FAISS index on the CPU
         faiss_config = index_config.faiss_config
-        assert faiss_config.dim == d, "The dimension of the index does not match the dimension of the embeddings!"
+        assert (
+            faiss_config.dim == d
+        ), "The dimension of the index does not match the dimension of the embeddings!"
         metric = getattr(faiss, faiss_config.metric)
         cpu_index = faiss.index_factory(
             faiss_config.dim,
@@ -99,7 +110,11 @@ def create_index(config):
 
         # Save the CPU index to disk
         index_path = os.path.join(
-            uniir_dir, index_dir_name, expt_dir_name, split_name, f"mbeir_{cand_pool_name}_{split_name}.index"
+            uniir_dir,
+            index_dir_name,
+            expt_dir_name,
+            split_name,
+            f"mbeir_{cand_pool_name}_{split_name}.index",
         )
         os.makedirs(os.path.dirname(index_path), exist_ok=True)
         faiss.write_index(index_cpu, index_path)
@@ -160,21 +175,29 @@ def load_qrel(filename):
     with open(filename, "r") as f:
         for line in f:
             query_id, _, doc_id, relevance_score, task_id = line.strip().split()
-            if int(relevance_score) > 0:  # Assuming only positive relevance scores indicate relevant documents
+            if (
+                int(relevance_score) > 0
+            ):  # Assuming only positive relevance scores indicate relevant documents
                 if query_id not in qrel:
                     qrel[query_id] = []
                 qrel[query_id].append(doc_id)
                 if query_id not in qid_to_taskid:
                     qid_to_taskid[query_id] = task_id
     print(f"Retriever: Loaded {len(qrel)} queries from {filename}")
-    print(f"Retriever: Average number of relevant documents per query: {sum(len(v) for v in qrel.values()) / len(qrel):.2f}")
+    print(
+        f"Retriever: Average number of relevant documents per query: {sum(len(v) for v in qrel.values()) / len(qrel):.2f}"
+    )
     return qrel, qid_to_taskid
 
 
-def search_index(query_embed_path, cand_index_path, batch_size=10, num_cand_to_retrieve=10):
+def search_index(
+    query_embed_path, cand_index_path, batch_size=10, num_cand_to_retrieve=10
+):
     # Load the full query embeddings
     query_embeddings = np.load(query_embed_path).astype("float32")
-    print(f"Faiss: loaded query embeddings from {query_embed_path} with shape: {query_embeddings.shape}")
+    print(
+        f"Faiss: loaded query embeddings from {query_embed_path} with shape: {query_embeddings.shape}"
+    )
 
     # Normalize the full query embeddings
     faiss.normalize_L2(query_embeddings)
@@ -189,15 +212,19 @@ def search_index(query_embed_path, cand_index_path, batch_size=10, num_cand_to_r
     print(f"Faiss: Number of GPUs used for searching: {ngpus}")
     co = faiss.GpuMultipleClonerOptions()
     co.shard = True  # Use shard to divide the data across the GPUs
-    index_gpu = faiss.index_cpu_to_all_gpus(index_cpu, co=co, ngpu=ngpus)  # This shards the index across all GPUs
+    index_gpu = faiss.index_cpu_to_all_gpus(
+        index_cpu, co=co, ngpu=ngpus
+    )  # This shards the index across all GPUs
 
     all_distances = []
     all_indices = []
 
     # Process in batches
     for i in range(0, len(query_embeddings), batch_size):
-        batch = query_embeddings[i: i + batch_size]
-        distances, indices = search_index_with_batch(batch, index_gpu, num_cand_to_retrieve)
+        batch = query_embeddings[i : i + batch_size]
+        distances, indices = search_index_with_batch(
+            batch, index_gpu, num_cand_to_retrieve
+        )
         all_distances.append(distances)
         all_indices.append(indices)
 
@@ -210,11 +237,16 @@ def search_index(query_embed_path, cand_index_path, batch_size=10, num_cand_to_r
 
 def search_index_with_batch(query_embeddings_batch, index_gpu, num_cand_to_retrieve=10):
     # Ensure query_embeddings_batch is numpy array with dtype float32
-    assert isinstance(query_embeddings_batch, np.ndarray) and query_embeddings_batch.dtype == np.float32
+    assert (
+        isinstance(query_embeddings_batch, np.ndarray)
+        and query_embeddings_batch.dtype == np.float32
+    )
     print(f"Faiss: query_embeddings_batch.shape: {query_embeddings_batch.shape}")
 
     # Query the multi-GPU index
-    distances, indices = index_gpu.search(query_embeddings_batch, num_cand_to_retrieve)  # (number_of_queries, k)
+    distances, indices = index_gpu.search(
+        query_embeddings_batch, num_cand_to_retrieve
+    )  # (number_of_queries, k)
     return distances, indices
 
 
@@ -226,6 +258,8 @@ def run_retrieval(config):
     qrel_dir_name = retrieval_config.qrel_dir_name
     embed_dir_name = retrieval_config.embed_dir_name
     index_dir_name = retrieval_config.index_dir_name
+    query_dir_name = retrieval_config.query_dir_name
+    candidate_dir_name = retrieval_config.candidate_dir_name
     expt_dir_name = config.experiment.path_suffix
 
     # Create results directory if it doesn't exist
@@ -233,6 +267,8 @@ def run_retrieval(config):
     exp_results_dir = os.path.join(uniir_dir, results_dir_name, expt_dir_name)
     os.makedirs(exp_results_dir, exist_ok=True)
     exp_run_file_dir = os.path.join(exp_results_dir, "run_files")
+    os.makedirs(exp_results_dir, exist_ok=True)
+    exp_retrieved_cands_dir = os.path.join(exp_results_dir, "retrieved_candidates")
     os.makedirs(exp_run_file_dir, exist_ok=True)
     exp_tsv_results_dir = os.path.join(exp_results_dir, "final_tsv")
     os.makedirs(exp_tsv_results_dir, exist_ok=True)
@@ -241,60 +277,116 @@ def run_retrieval(config):
     # Load the dataset splits to embed
     dataset_types = ["train", "val", "test"]
     for split_name in dataset_types:
-        retrieval_dataset_config = getattr(retrieval_config, f"{split_name}_datasets_config", None)
+        retrieval_dataset_config = getattr(
+            retrieval_config, f"{split_name}_datasets_config", None
+        )
         if retrieval_dataset_config and retrieval_dataset_config.enable_retrieve:
             dataset_name_list = getattr(retrieval_dataset_config, "datasets_name", None)
-            cand_pool_name_list = getattr(retrieval_dataset_config, "correspond_cand_pools_name", None)
-            qrel_name_list = getattr(retrieval_dataset_config, "correspond_qrels_name", None)
-            metric_names_list = getattr(retrieval_dataset_config, "correspond_metrics_name", None)
-            dataset_embed_dir = os.path.join(uniir_dir, embed_dir_name, expt_dir_name, split_name)
-            splits.append((split_name, dataset_embed_dir, dataset_name_list, cand_pool_name_list, qrel_name_list, metric_names_list))
-            assert len(dataset_name_list) == len(cand_pool_name_list) == len(
-                qrel_name_list) == len(metric_names_list), "Mismatch between datasets and candidate pools and qrels."
+            cand_pool_name_list = getattr(
+                retrieval_dataset_config, "correspond_cand_pools_name", None
+            )
+            qrel_name_list = getattr(
+                retrieval_dataset_config, "correspond_qrels_name", None
+            )
+            metric_names_list = getattr(
+                retrieval_dataset_config, "correspond_metrics_name", None
+            )
+            dataset_embed_dir = os.path.join(
+                uniir_dir, embed_dir_name, expt_dir_name, split_name
+            )
+            splits.append(
+                (
+                    split_name,
+                    dataset_embed_dir,
+                    dataset_name_list,
+                    cand_pool_name_list,
+                    qrel_name_list,
+                    metric_names_list,
+                )
+            )
+            assert (
+                len(dataset_name_list)
+                == len(cand_pool_name_list)
+                == len(qrel_name_list)
+                == len(metric_names_list)
+            ), "Mismatch between datasets and candidate pools and qrels."
 
     # Pretty Print dataset to index
     print("-" * 30)
-    for split_name, dataset_embed_dir, dataset_name_list, cand_pool_name_list, qrel_name_list, metric_names_list in splits:
-        print(f"Split: {split_name}, Retrieval Datasets: {dataset_name_list}, Candidate Pools: {cand_pool_name_list}, Metric: {metric_names_list})")
+    for (
+        split_name,
+        dataset_embed_dir,
+        dataset_name_list,
+        cand_pool_name_list,
+        qrel_name_list,
+        metric_names_list,
+    ) in splits:
+        print(
+            f"Split: {split_name}, Retrieval Datasets: {dataset_name_list}, Candidate Pools: {cand_pool_name_list}, Metric: {metric_names_list})"
+        )
         print("-" * 30)
 
     eval_results = []
     cand_index_dir = os.path.join(uniir_dir, index_dir_name, expt_dir_name, "cand_pool")
     qrel_dir = os.path.join(mbeir_data_dir, qrel_dir_name)
-    for split, dataset_embed_dir, dataset_name_list, cand_pool_name_list, qrel_name_list, metric_names_list in splits:
-        for dataset_name, cand_pool_name, qrel_name, metric_names in zip(dataset_name_list, cand_pool_name_list, qrel_name_list, metric_names_list):
+    for (
+        split,
+        dataset_embed_dir,
+        dataset_name_list,
+        cand_pool_name_list,
+        qrel_name_list,
+        metric_names_list,
+    ) in splits:
+        for dataset_name, cand_pool_name, qrel_name, metric_names in zip(
+            dataset_name_list, cand_pool_name_list, qrel_name_list, metric_names_list
+        ):
             print("\n" + "-" * 30)
-            print(f"Retriever: Retrieving for query:{dataset_name} | split:{split} | from cand_pool:{cand_pool_name}")
+            print(
+                f"Retriever: Retrieving for query:{dataset_name} | split:{split} | from cand_pool:{cand_pool_name}"
+            )
 
             dataset_name = dataset_name.lower()
             cand_pool_name = cand_pool_name.lower()
             qrel_name = qrel_name.lower()
 
             # Load qrels
-            qrel_path = os.path.join(qrel_dir, split, f"mbeir_{qrel_name}_{split}_qrels.txt")
+            qrel_path = os.path.join(
+                qrel_dir, split, f"mbeir_{qrel_name}_{split}_qrels.txt"
+            )
             qrel, qid_to_taskid = load_qrel(qrel_path)
 
             # Load query Hashed IDs
-            embed_query_id_path = os.path.join(dataset_embed_dir, f"mbeir_{dataset_name}_{split}_ids.npy")
+            embed_query_id_path = os.path.join(
+                dataset_embed_dir, f"mbeir_{dataset_name}_{split}_ids.npy"
+            )
             hashed_query_ids = np.load(embed_query_id_path)
 
             # Load query embeddings
-            embed_query_path = os.path.join(dataset_embed_dir, f"mbeir_{dataset_name}_{split}_embed.npy")
+            embed_query_path = os.path.join(
+                dataset_embed_dir, f"mbeir_{dataset_name}_{split}_embed.npy"
+            )
 
             # Load the candidate pool index
-            cand_index_path = os.path.join(cand_index_dir, f"mbeir_{cand_pool_name}_cand_pool.index")
+            cand_index_path = os.path.join(
+                cand_index_dir, f"mbeir_{cand_pool_name}_cand_pool.index"
+            )
 
             # Set up the metric
             # e.g. "Recall@1, Recall@5, Recall@10"
             # TODO: add more metrics
-            metric_list = [metric.strip() for metric in metric_names.split(',')]
-            metric_recall_list = [metric for metric in metric_list if "recall" in metric.lower()]
+            metric_list = [metric.strip() for metric in metric_names.split(",")]
+            metric_recall_list = [
+                metric for metric in metric_list if "recall" in metric.lower()
+            ]
 
             # Search the index
-            k = max([int(metric.split('@')[1]) for metric in metric_recall_list])
+            k = max([int(metric.split("@")[1]) for metric in metric_recall_list])
             print(f"Retriever: Searching with k={k}")
             retrieved_cand_dist, retrieved_indices = search_index(
-                embed_query_path, cand_index_path, batch_size=hashed_query_ids.shape[0], num_cand_to_retrieve=k
+                embed_query_path,
+                cand_index_path,
+                batch_size=hashed_query_ids.shape[0],
+                num_cand_to_retrieve=k,
             )  # Shape: (number_of_queries, k)
 
             # Open a file to write the run results
@@ -304,32 +396,95 @@ def run_retrieval(config):
                 run_id = f"mbeir_{dataset_name}_single_pool_{split}_k{k}"
             run_file_name = f"{run_id}_run.txt"
             run_file_path = os.path.join(exp_run_file_dir, run_file_name)
-            with open(run_file_path, 'w') as run_file:
-                for idx, (distances, indices) in enumerate(zip(retrieved_cand_dist, retrieved_indices)):
+            with open(run_file_path, "w") as run_file:
+                for idx, (distances, indices) in enumerate(
+                    zip(retrieved_cand_dist, retrieved_indices)
+                ):
                     qid = unhash_qid(hashed_query_ids[idx])
                     task_id = qid_to_taskid[qid]
-                    for rank, (hashed_doc_id, score) in enumerate(zip(indices, distances), start=1):
+                    for rank, (hashed_doc_id, score) in enumerate(
+                        zip(indices, distances), start=1
+                    ):
                         # Format: query-id Q0 document-id rank score run-id task_id
                         # We can remove task_id if we don't need it later using a helper
                         # Note: since we are using the cosine similarity, we don't need to invert the scores.
                         doc_id = unhash_did(hashed_doc_id)
-                        run_file_line = f"{qid} Q0 {doc_id} {rank} {score} {run_id} {task_id}\n"
+                        run_file_line = (
+                            f"{qid} Q0 {doc_id} {rank} {score} {run_id} {task_id}\n"
+                        )
                         run_file.write(run_file_line)
             print(f"Retriever: Run file saved to {run_file_path}")
+
+        # Save raw retrieve candidates for downstream applications like UniRAG
+        if retrieval_config.raw_retrieval:
+            # Load raw queries
+            queries_path = os.path.join(
+                mbeir_data_dir,
+                query_dir_name,
+                f"{split}/mbeir_{dataset_name}_{split}.jsonl",
+            )
+            qid_to_queries = {}
+            with open(queries_path, "r") as f:
+                for l in f:
+                    q = json.loads(l.strip())
+                    assert q["qid"] not in qid_to_queries, "qids must be unique"
+                    qid_to_queries[q["qid"]] = q
+
+            # Load raw candidates
+            candidate_file_name = f"mbeir_{cand_pool_name}_{split}_cand_pool.jsonl"
+            candidates_path = os.path.join(
+                mbeir_data_dir, candidate_dir_name, candidate_file_name
+            )
+            did_to_candidates = {}
+            with open(candidates_path, "r") as f:
+                for l in f:
+                    c = json.loads(l.strip())
+                    assert c["did"] not in did_to_candidates, "dids must be unique"
+                    did_to_candidates[c["did"]] = c
+
+            # Save raw retrieved results
+            retrieved_file_name = f"{run_id}_retrieved.txt"
+            retrieved_file_path = os.path.join(
+                exp_retrieved_cands_dir, retrieved_file_name
+            )
+            with open(retrieved_file_path, "w") as run_file:
+                for idx, (distances, indices) in enumerate(
+                    zip(retrieved_cand_dist, retrieved_indices)
+                ):
+                    retrieved_cands = []
+                    qid = unhash_qid(hashed_query_ids[idx])
+                    query = qid_to_queries[qid]
+                    task_id = qid_to_taskid[qid]
+                    for rank, (hashed_doc_id, score) in enumerate(
+                        zip(indices, distances), start=1
+                    ):
+                        doc_id = unhash_did(hashed_doc_id)
+                        retrieved_cands.append(did_to_candidates[doc_id])
+                    json.dump(
+                        {"query": query, "candidates": retrieved_cands},
+                        retrieved_file_path,
+                    )
+                    retrieved_file_path.write("\n")
+
+            print(f"Retriever: Run file saved to {retrieved_file_path}")
 
             # Compute Recall@k
             recall_values_by_task = defaultdict(lambda: defaultdict(list))
             for i, retrieved_indices_for_qid in enumerate(retrieved_indices):
                 # Map the retrieved FAISS indices to the original mbeir_data_ids
-                retrieved_indices_for_qid = [unhash_did(idx) for idx in retrieved_indices_for_qid]
+                retrieved_indices_for_qid = [
+                    unhash_did(idx) for idx in retrieved_indices_for_qid
+                ]
                 qid = unhash_qid(hashed_query_ids[i])
                 relevant_docs = qrel[qid]
                 task_id = qid_to_taskid[qid]
 
                 # Compute Recall@k for each metric
                 for metric in metric_recall_list:
-                    k = int(metric.split('@')[1])
-                    recall_at_k = compute_recall_at_k(relevant_docs, retrieved_indices_for_qid, k)
+                    k = int(metric.split("@")[1])
+                    recall_at_k = compute_recall_at_k(
+                        relevant_docs, retrieved_indices_for_qid, k
+                    )
                     recall_values_by_task[task_id][metric].append(recall_at_k)
 
             for task_id, recalls in recall_values_by_task.items():
@@ -342,7 +497,9 @@ def run_retrieval(config):
                     "CandPool": cand_pool_name,
                 }
                 for metric in metric_recall_list:
-                    mean_recall_at_k = round(sum(recalls[metric]) / len(recalls[metric]), 4)
+                    mean_recall_at_k = round(
+                        sum(recalls[metric]) / len(recalls[metric]), 4
+                    )
                     result[metric] = mean_recall_at_k
                     print(f"Retriever: Mean {metric}: {mean_recall_at_k}")
                 eval_results.append(result)
@@ -367,23 +524,38 @@ def run_retrieval(config):
         "oven_task8": 15,
         "infoseek_task8": 16,
     }
-    split_order = {'val': 1, 'test': 2}
-    cand_pool_order = {'union': 99}
-    eval_results_sorted = sorted(eval_results, key=lambda x: (
-        x["TaskID"],
-        dataset_order.get(x["Dataset"].lower(), 99),  # default to 99 for datasets not listed
-        split_order.get(x["Split"].lower(), 99),  # default to 99 for splits not listed
-        cand_pool_order.get(x["CandPool"].lower(), 0),
-    ))
+    split_order = {"val": 1, "test": 2}
+    cand_pool_order = {"union": 99}
+    eval_results_sorted = sorted(
+        eval_results,
+        key=lambda x: (
+            x["TaskID"],
+            dataset_order.get(
+                x["Dataset"].lower(), 99
+            ),  # default to 99 for datasets not listed
+            split_order.get(
+                x["Split"].lower(), 99
+            ),  # default to 99 for splits not listed
+            cand_pool_order.get(x["CandPool"].lower(), 0),
+        ),
+    )
 
     grouped_results = defaultdict(lambda: defaultdict(lambda: defaultdict(dict)))
 
     # Populate the grouped_results with metric values
-    available_recall_metrics = ["Recall@1", "Recall@5", "Recall@10", "Recall@20", "Recall@50"]
+    available_recall_metrics = [
+        "Recall@1",
+        "Recall@5",
+        "Recall@10",
+        "Recall@20",
+        "Recall@50",
+    ]
     for result in eval_results_sorted:
         key = (result["TaskID"], result["Task"], result["Dataset"], result["Split"])
         for metric in available_recall_metrics:
-            grouped_results[key][result["CandPool"]].update({metric: result.get(metric, None)})
+            grouped_results[key][result["CandPool"]].update(
+                {metric: result.get(metric, None)}
+            )
 
     # Write the sorted data to TSV
     if retrieval_config.write_to_tsv:
@@ -392,7 +564,17 @@ def run_retrieval(config):
         tsv_file_name = f"eval_results_{date_time}.tsv"
         tsv_file_path = os.path.join(exp_tsv_results_dir, tsv_file_name)
         tsv_data = []
-        header = ["TaskID", "Task", "Dataset", "Split", "Metric", "CandPool", "Value", "UnionPool", "UnionValue"]
+        header = [
+            "TaskID",
+            "Task",
+            "Dataset",
+            "Split",
+            "Metric",
+            "CandPool",
+            "Value",
+            "UnionPool",
+            "UnionValue",
+        ]
         tsv_data.append(header)
 
         for (task_id, task, dataset, split), cand_pools in grouped_results.items():
@@ -400,8 +582,18 @@ def run_retrieval(config):
             union_results = cand_pools.get("union", {})
             for metric in available_recall_metrics:
                 for cand_pool, metrics in cand_pools.items():
-                    if cand_pool != "union":  # Exclude union pool as it's handled separately
-                        row = [task_id, task, dataset, split, metric, cand_pool, metrics.get(metric, None)]
+                    if (
+                        cand_pool != "union"
+                    ):  # Exclude union pool as it's handled separately
+                        row = [
+                            task_id,
+                            task,
+                            dataset,
+                            split,
+                            metric,
+                            cand_pool,
+                            metrics.get(metric, None),
+                        ]
                         # Skip metric if it's not available
                         if row[-1] is None:
                             continue
@@ -409,12 +601,14 @@ def run_retrieval(config):
                         if union_results:
                             row.extend(["union", union_results.get(metric, "N/A")])
                         else:
-                            row.extend(["", ""])  # Fill with empty values if no union result
+                            row.extend(
+                                ["", ""]
+                            )  # Fill with empty values if no union result
                         tsv_data.append(row)
 
         # Write to TSV
-        with open(tsv_file_path, 'w', newline='') as tsvfile:
-            writer = csv.writer(tsvfile, delimiter='\t')
+        with open(tsv_file_path, "w", newline="") as tsvfile:
+            writer = csv.writer(tsvfile, delimiter="\t")
             for row in tsv_data:
                 writer.writerow(row)
 
@@ -432,41 +626,60 @@ def run_hard_negative_mining(config):
 
     # Query data file name
     retrieval_train_dataset_config = retrieval_config.train_datasets_config
-    assert retrieval_train_dataset_config.enable_retrieve, "Hard negative mining is not enabled for training data"
+    assert (
+        retrieval_train_dataset_config.enable_retrieve
+    ), "Hard negative mining is not enabled for training data"
     dataset_name = retrieval_train_dataset_config.datasets_name[
         0
     ].lower()  # Only extract hard negatives for the first dataset
     dataset_split_name = "train"
     # Load query data
-    query_data_path = os.path.join(mbeir_data_dir, "train", f"mbeir_{dataset_name}_{dataset_split_name}.jsonl")
+    query_data_path = os.path.join(
+        mbeir_data_dir, "train", f"mbeir_{dataset_name}_{dataset_split_name}.jsonl"
+    )
     query_data_list = load_jsonl_as_list(query_data_path)
 
     # Load query IDs
-    dataset_embed_dir = os.path.join(uniir_dir, embed_dir_name, expt_dir_name, dataset_split_name)
-    embed_data_id_path = os.path.join(dataset_embed_dir, f"mbeir_{dataset_name}_{dataset_split_name}_ids.npy")
+    dataset_embed_dir = os.path.join(
+        uniir_dir, embed_dir_name, expt_dir_name, dataset_split_name
+    )
+    embed_data_id_path = os.path.join(
+        dataset_embed_dir, f"mbeir_{dataset_name}_{dataset_split_name}_ids.npy"
+    )
     query_ids = np.load(embed_data_id_path)
 
     # Load query embeddings
-    embed_data_path = os.path.join(dataset_embed_dir, f"mbeir_{dataset_name}_{dataset_split_name}_embed.npy")
+    embed_data_path = os.path.join(
+        dataset_embed_dir, f"mbeir_{dataset_name}_{dataset_split_name}_embed.npy"
+    )
 
     # Load the candidate pool index
     cand_pool_name = retrieval_train_dataset_config.correspond_cand_pools_name[
         0
     ].lower()  # Only extract the first candidate pool
     cand_pool_split_name = "cand_pool"
-    cand_index_dir = os.path.join(uniir_dir, index_dir_name, expt_dir_name, cand_pool_split_name)
-    cand_index_path = os.path.join(cand_index_dir, f"mbeir_{cand_pool_name}_{cand_pool_split_name}.index")
+    cand_index_dir = os.path.join(
+        uniir_dir, index_dir_name, expt_dir_name, cand_pool_split_name
+    )
+    cand_index_path = os.path.join(
+        cand_index_dir, f"mbeir_{cand_pool_name}_{cand_pool_split_name}.index"
+    )
 
     # Pretty Print dataset to perform hard negative mining
     print("-" * 30)
-    print(f"Hard Negative mining, Datasets: {dataset_name}, Candidate Pools: {cand_pool_name}")
+    print(
+        f"Hard Negative mining, Datasets: {dataset_name}, Candidate Pools: {cand_pool_name}"
+    )
     print("-" * 30)
 
     # Search the index
     num_hard_negs = retrieval_config.num_hard_negs
     k = retrieval_config.k
     _, retrieved_indices = search_index(
-        embed_data_path, cand_index_path, batch_size=query_ids.shape[0], num_cand_to_retrieve=k
+        embed_data_path,
+        cand_index_path,
+        batch_size=query_ids.shape[0],
+        num_cand_to_retrieve=k,
     )  # nested list of (number_of_queries, k)
     assert len(query_ids) == len(retrieved_indices)
 
@@ -476,7 +689,9 @@ def run_hard_negative_mining(config):
         query_id = unhash_qid(query_id)
         assert query_id == query_data["qid"]
         retrieved_indices_for_qid = retrieved_indices[i]
-        retrieved_indices_for_qid = [unhash_did(idx) for idx in retrieved_indices_for_qid]
+        retrieved_indices_for_qid = [
+            unhash_did(idx) for idx in retrieved_indices_for_qid
+        ]
 
         pos_cand_list = query_data["pos_cand_list"]
         neg_cand_list = query_data["neg_cand_list"]
@@ -502,19 +717,30 @@ def run_hard_negative_mining(config):
 
     # Save the query data with hard negatives
     query_data_with_hard_negs_path = os.path.join(
-        mbeir_data_dir, "train", hard_negs_dir_name, f"mbeir_{dataset_name}_hard_negs_{dataset_split_name}.jsonl"
+        mbeir_data_dir,
+        "train",
+        hard_negs_dir_name,
+        f"mbeir_{dataset_name}_hard_negs_{dataset_split_name}.jsonl",
     )  # mbeir_data_dir/train/hard_negs_dir_name/mbeir_agg_hard_negs_train.jsonl
     os.makedirs(os.path.dirname(query_data_with_hard_negs_path), exist_ok=True)
     save_list_as_jsonl(query_data_list, query_data_with_hard_negs_path)
 
     # Print statistics
     total_entries, _data = count_entries_in_file(query_data_with_hard_negs_path)
-    print(f"MBEIR Train Data with Hard Negatives saved to {query_data_with_hard_negs_path}")
-    print(f"Total number of entries in {query_data_with_hard_negs_path}: {total_entries}")
-    cand_pool_path = os.path.join(
-        mbeir_data_dir, cand_pool_split_name, f"mbeir_{cand_pool_name}_{cand_pool_split_name}.jsonl"
+    print(
+        f"MBEIR Train Data with Hard Negatives saved to {query_data_with_hard_negs_path}"
     )
-    cand_pool = load_mbeir_format_pool_file_as_dict(cand_pool_path, doc_key_to_content=True, key_type="did")
+    print(
+        f"Total number of entries in {query_data_with_hard_negs_path}: {total_entries}"
+    )
+    cand_pool_path = os.path.join(
+        mbeir_data_dir,
+        cand_pool_split_name,
+        f"mbeir_{cand_pool_name}_{cand_pool_split_name}.jsonl",
+    )
+    cand_pool = load_mbeir_format_pool_file_as_dict(
+        cand_pool_path, doc_key_to_content=True, key_type="did"
+    )
     print_mbeir_format_dataset_stats(_data, cand_pool)
 
 
@@ -522,10 +748,20 @@ def parse_arguments():
     parser = argparse.ArgumentParser(description="FAISS Pipeline")
     parser.add_argument("--uniir_dir", type=str, default="/data/UniIR")
     parser.add_argument("--mbeir_data_dir", type=str, default="/data/UniIR/mbeir_data")
-    parser.add_argument("--config_path", default="config.yaml", help="Path to the config file.")
-    parser.add_argument("--enable_create_index", action="store_true", help="Enable create index")
-    parser.add_argument("--enable_hard_negative_mining", action="store_true", help="Enable hard negative mining")
-    parser.add_argument("--enable_retrieval", action="store_true", help="Enable retrieval")
+    parser.add_argument(
+        "--config_path", default="config.yaml", help="Path to the config file."
+    )
+    parser.add_argument(
+        "--enable_create_index", action="store_true", help="Enable create index"
+    )
+    parser.add_argument(
+        "--enable_hard_negative_mining",
+        action="store_true",
+        help="Enable hard negative mining",
+    )
+    parser.add_argument(
+        "--enable_retrieval", action="store_true", help="Enable retrieval"
+    )
     return parser.parse_args()
 
 

--- a/src/common/mbeir_retriever.py
+++ b/src/common/mbeir_retriever.py
@@ -460,8 +460,15 @@ def run_retrieval(config):
                     ):
                         doc_id = unhash_did(hashed_doc_id)
                         retrieved_cands.append(did_to_candidates[doc_id])
+                    retrieved_dict = {"query": query, "candidates": retrieved_cands}
+                    if retrieval_config.retrieve_image_text_pairs:
+                        # TODO(sahel): Populate the complement candidates by retrieving the top 1 candidate
+                        # for each retrieved candidate. The complement candidate will have the complementary
+                        # modality (i.e. image for text candidates, and text for image candidates).
+                        complement_candidates = []
+                        retrieved_dict["complement_candidates"] = complement_candidates
                     json.dump(
-                        {"query": query, "candidates": retrieved_cands},
+                        retrieved_dict,
                         retrieved_file_path,
                     )
                     retrieved_file_path.write("\n")

--- a/src/common/mbeir_retriever.py
+++ b/src/common/mbeir_retriever.py
@@ -248,7 +248,7 @@ def run_retrieval(config):
     exp_run_file_dir = os.path.join(exp_results_dir, "run_files")
     os.makedirs(exp_results_dir, exist_ok=True)
     exp_retrieved_cands_dir = os.path.join(exp_results_dir, "retrieved_candidates")
-    os.makedirs(exp_run_file_dir, exist_ok=True)
+    os.makedirs(exp_retrieved_cands_dir, exist_ok=True)
     exp_tsv_results_dir = os.path.join(exp_results_dir, "final_tsv")
     os.makedirs(exp_tsv_results_dir, exist_ok=True)
 

--- a/src/common/mbeir_retriever.py
+++ b/src/common/mbeir_retriever.py
@@ -255,6 +255,7 @@ def get_raw_retrieved_candidates(queries_path, candidates_path, retrieved_indice
             doc_id = unhash_did(hashed_doc_id)
             retrieved_cands.append(did_to_candidates[doc_id])
         retrieved_dict[qid] = {"query": query, "candidates": retrieved_cands}
+    # TODO: retrieve the complement candidates when retrieve_image_text_pairs is enabled.
     return retrieved_dict
 
 
@@ -411,7 +412,7 @@ def run_retrieval(config, query_embedder_config):
                     for _, v in retrieved_dict.items():
                         json.dump(v, retrieved_file)
                         retrieved_file.write("\n")
-                print(f"Retriever: Run file saved to {retrieved_file_path}")
+                print(f"Retriever: Retrieved file saved to {retrieved_file_path}")
 
             # Compute Recall@k
             recall_values_by_task = defaultdict(lambda: defaultdict(list))

--- a/src/common/mbeir_retriever.py
+++ b/src/common/mbeir_retriever.py
@@ -380,9 +380,7 @@ def run_retrieval(config):
 
             # Load raw candidates
             candidate_file_name = f"mbeir_{cand_pool_name}_{split}_cand_pool.jsonl"
-            candidates_path = os.path.join(
-                mbeir_data_dir, candidate_dir_name, candidate_file_name
-            )
+            candidates_path = os.path.join(mbeir_data_dir, candidate_dir_name, candidate_file_name)
             did_to_candidates = {}
             with open(candidates_path, "r") as f:
                 for l in f:
@@ -392,20 +390,14 @@ def run_retrieval(config):
 
             # Save raw retrieved results
             retrieved_file_name = f"{run_id}_retrieved.txt"
-            retrieved_file_path = os.path.join(
-                exp_retrieved_cands_dir, retrieved_file_name
-            )
+            retrieved_file_path = os.path.join(exp_retrieved_cands_dir, retrieved_file_name)
             with open(retrieved_file_path, "w") as run_file:
-                for idx, (distances, indices) in enumerate(
-                    zip(retrieved_cand_dist, retrieved_indices)
-                ):
+                for idx, (distances, indices) in enumerate(zip(retrieved_cand_dist, retrieved_indices)):
                     retrieved_cands = []
                     qid = unhash_qid(hashed_query_ids[idx])
                     query = qid_to_queries[qid]
                     task_id = qid_to_taskid[qid]
-                    for rank, (hashed_doc_id, score) in enumerate(
-                        zip(indices, distances), start=1
-                    ):
+                    for rank, (hashed_doc_id, score) in enumerate(zip(indices, distances), start=1):
                         doc_id = unhash_did(hashed_doc_id)
                         retrieved_cands.append(did_to_candidates[doc_id])
                     retrieved_dict = {"query": query, "candidates": retrieved_cands}

--- a/src/models/uniir_blip/blip_featurefusion/configs_scripts/base/eval/inbatch/retrieval.yaml
+++ b/src/models/uniir_blip/blip_featurefusion/configs_scripts/base/eval/inbatch/retrieval.yaml
@@ -18,6 +18,7 @@ retrieval_config:
 
     # For using retrieved candidates in downstream applications like RAG.
     raw_retrieval: False # Store raw queries and their retrieved candidates
+    retrieve_image_text_pairs: False # During raw retrieval always retrieve imge-text pairs.
     query_dir_name: # Raw queries will be loaded from mbeir_data_dir/query_dir_name
     candidate_dir_name: # Raw retrieved candidates will be loaded from mbeir_data_dir/cand_pool/candidate_dir_name
 

--- a/src/models/uniir_blip/blip_featurefusion/configs_scripts/base/eval/inbatch/retrieval.yaml
+++ b/src/models/uniir_blip/blip_featurefusion/configs_scripts/base/eval/inbatch/retrieval.yaml
@@ -16,6 +16,11 @@ retrieval_config:
 
     write_to_tsv: True  # Write the results to csv files
 
+    # For using retrieved candidates in downstream applications like RAG.
+    raw_retrieval: False # Store raw queries and their retrieved candidates
+    query_dir_name: # Raw queries will be loaded from mbeir_data_dir/query_dir_name
+    candidate_dir_name: # Raw retrieved candidates will be loaded from mbeir_data_dir/cand_pool/candidate_dir_name
+
     # For Retrieval Evaluation
     train_datasets_config:
         enable_retrieve: False

--- a/src/models/uniir_blip/blip_featurefusion/configs_scripts/large/eval/inbatch/retrieval.yaml
+++ b/src/models/uniir_blip/blip_featurefusion/configs_scripts/large/eval/inbatch/retrieval.yaml
@@ -18,6 +18,7 @@ retrieval_config:
 
     # For using retrieved candidates in downstream applications like RAG.
     raw_retrieval: False # Store raw queries and their retrieved candidates
+    retrieve_image_text_pairs: False # During raw retrieval always retrieve imge-text pairs.
     query_dir_name: # Raw queries will be loaded from mbeir_data_dir/query_dir_name
     candidate_dir_name: # Raw retrieved candidates will be loaded from mbeir_data_dir/cand_pool/candidate_dir_name
 

--- a/src/models/uniir_blip/blip_featurefusion/configs_scripts/large/eval/inbatch/retrieval.yaml
+++ b/src/models/uniir_blip/blip_featurefusion/configs_scripts/large/eval/inbatch/retrieval.yaml
@@ -16,6 +16,11 @@ retrieval_config:
 
     write_to_tsv: True  # Write the results to csv files
 
+    # For using retrieved candidates in downstream applications like RAG.
+    raw_retrieval: False # Store raw queries and their retrieved candidates
+    query_dir_name: # Raw queries will be loaded from mbeir_data_dir/query_dir_name
+    candidate_dir_name: # Raw retrieved candidates will be loaded from mbeir_data_dir/cand_pool/candidate_dir_name
+
     # For Retrieval Evaluation
     train_datasets_config:
         enable_retrieve: False

--- a/src/models/uniir_blip/blip_scorefusion/configs_scripts/base/eval/inbatch/retrieval.yaml
+++ b/src/models/uniir_blip/blip_scorefusion/configs_scripts/base/eval/inbatch/retrieval.yaml
@@ -18,6 +18,7 @@ retrieval_config:
 
     # For using retrieved candidates in downstream applications like RAG.
     raw_retrieval: False # Store raw queries and their retrieved candidates
+    retrieve_image_text_pairs: False # During raw retrieval always retrieve imge-text pairs.
     query_dir_name: # Raw queries will be loaded from mbeir_data_dir/query_dir_name
     candidate_dir_name: # Raw retrieved candidates will be loaded from mbeir_data_dir/cand_pool/candidate_dir_name
 

--- a/src/models/uniir_blip/blip_scorefusion/configs_scripts/base/eval/inbatch/retrieval.yaml
+++ b/src/models/uniir_blip/blip_scorefusion/configs_scripts/base/eval/inbatch/retrieval.yaml
@@ -16,6 +16,11 @@ retrieval_config:
 
     write_to_tsv: True  # Write the results to csv files
 
+    # For using retrieved candidates in downstream applications like RAG.
+    raw_retrieval: False # Store raw queries and their retrieved candidates
+    query_dir_name: # Raw queries will be loaded from mbeir_data_dir/query_dir_name
+    candidate_dir_name: # Raw retrieved candidates will be loaded from mbeir_data_dir/cand_pool/candidate_dir_name
+
     # For Retrieval Evaluation
     train_datasets_config:
         enable_retrieve: False

--- a/src/models/uniir_blip/blip_scorefusion/configs_scripts/large/eval/inbatch/retrieval.yaml
+++ b/src/models/uniir_blip/blip_scorefusion/configs_scripts/large/eval/inbatch/retrieval.yaml
@@ -18,6 +18,7 @@ retrieval_config:
 
     # For using retrieved candidates in downstream applications like RAG.
     raw_retrieval: False # Store raw queries and their retrieved candidates
+    retrieve_image_text_pairs: False # During raw retrieval always retrieve imge-text pairs.
     query_dir_name: # Raw queries will be loaded from mbeir_data_dir/query_dir_name
     candidate_dir_name: # Raw retrieved candidates will be loaded from mbeir_data_dir/cand_pool/candidate_dir_name
 

--- a/src/models/uniir_blip/blip_scorefusion/configs_scripts/large/eval/inbatch/retrieval.yaml
+++ b/src/models/uniir_blip/blip_scorefusion/configs_scripts/large/eval/inbatch/retrieval.yaml
@@ -16,6 +16,11 @@ retrieval_config:
 
     write_to_tsv: True  # Write the results to csv files
 
+    # For using retrieved candidates in downstream applications like RAG.
+    raw_retrieval: False # Store raw queries and their retrieved candidates
+    query_dir_name: # Raw queries will be loaded from mbeir_data_dir/query_dir_name
+    candidate_dir_name: # Raw retrieved candidates will be loaded from mbeir_data_dir/cand_pool/candidate_dir_name
+
     # For Retrieval Evaluation
     train_datasets_config:
         enable_retrieve: False

--- a/src/models/uniir_clip/clip_featurefusion/configs_scripts/base/eval/inbatch/retrieval.yaml
+++ b/src/models/uniir_clip/clip_featurefusion/configs_scripts/base/eval/inbatch/retrieval.yaml
@@ -18,6 +18,7 @@ retrieval_config:
 
     # For using retrieved candidates in downstream applications like RAG.
     raw_retrieval: False # Store raw queries and their retrieved candidates
+    retrieve_image_text_pairs: False # During raw retrieval always retrieve imge-text pairs.
     query_dir_name: # Raw queries will be loaded from mbeir_data_dir/query_dir_name
     candidate_dir_name: # Raw retrieved candidates will be loaded from mbeir_data_dir/cand_pool/candidate_dir_name
 

--- a/src/models/uniir_clip/clip_featurefusion/configs_scripts/base/eval/inbatch/retrieval.yaml
+++ b/src/models/uniir_clip/clip_featurefusion/configs_scripts/base/eval/inbatch/retrieval.yaml
@@ -16,6 +16,11 @@ retrieval_config:
 
     write_to_tsv: True  # Write the results to csv files
 
+    # For using retrieved candidates in downstream applications like RAG.
+    raw_retrieval: False # Store raw queries and their retrieved candidates
+    query_dir_name: # Raw queries will be loaded from mbeir_data_dir/query_dir_name
+    candidate_dir_name: # Raw retrieved candidates will be loaded from mbeir_data_dir/cand_pool/candidate_dir_name
+
     # For Retrieval Evaluation
     train_datasets_config:
         enable_retrieve: False

--- a/src/models/uniir_clip/clip_featurefusion/configs_scripts/large/eval/inbatch/retrieval.yaml
+++ b/src/models/uniir_clip/clip_featurefusion/configs_scripts/large/eval/inbatch/retrieval.yaml
@@ -18,6 +18,7 @@ retrieval_config:
 
     # For using retrieved candidates in downstream applications like RAG.
     raw_retrieval: False # Store raw queries and their retrieved candidates
+    retrieve_image_text_pairs: False # During raw retrieval always retrieve imge-text pairs.
     query_dir_name: # Raw queries will be loaded from mbeir_data_dir/query_dir_name
     candidate_dir_name: # Raw retrieved candidates will be loaded from mbeir_data_dir/cand_pool/candidate_dir_name
 

--- a/src/models/uniir_clip/clip_featurefusion/configs_scripts/large/eval/inbatch/retrieval.yaml
+++ b/src/models/uniir_clip/clip_featurefusion/configs_scripts/large/eval/inbatch/retrieval.yaml
@@ -16,6 +16,11 @@ retrieval_config:
 
     write_to_tsv: True  # Write the results to csv files
 
+    # For using retrieved candidates in downstream applications like RAG.
+    raw_retrieval: False # Store raw queries and their retrieved candidates
+    query_dir_name: # Raw queries will be loaded from mbeir_data_dir/query_dir_name
+    candidate_dir_name: # Raw retrieved candidates will be loaded from mbeir_data_dir/cand_pool/candidate_dir_name
+
     # For Retrieval Evaluation
     train_datasets_config:
         enable_retrieve: False

--- a/src/models/uniir_clip/clip_scorefusion/configs_scripts/base/eval/inbatch/retrieval.yaml
+++ b/src/models/uniir_clip/clip_scorefusion/configs_scripts/base/eval/inbatch/retrieval.yaml
@@ -18,6 +18,7 @@ retrieval_config:
 
     # For using retrieved candidates in downstream applications like RAG.
     raw_retrieval: False # Store raw queries and their retrieved candidates
+    retrieve_image_text_pairs: False # During raw retrieval always retrieve imge-text pairs.
     query_dir_name: # Raw queries will be loaded from mbeir_data_dir/query_dir_name
     candidate_dir_name: # Raw retrieved candidates will be loaded from mbeir_data_dir/cand_pool/candidate_dir_name
 

--- a/src/models/uniir_clip/clip_scorefusion/configs_scripts/base/eval/inbatch/retrieval.yaml
+++ b/src/models/uniir_clip/clip_scorefusion/configs_scripts/base/eval/inbatch/retrieval.yaml
@@ -16,6 +16,11 @@ retrieval_config:
 
     write_to_tsv: True  # Write the results to csv files
 
+    # For using retrieved candidates in downstream applications like RAG.
+    raw_retrieval: False # Store raw queries and their retrieved candidates
+    query_dir_name: # Raw queries will be loaded from mbeir_data_dir/query_dir_name
+    candidate_dir_name: # Raw retrieved candidates will be loaded from mbeir_data_dir/cand_pool/candidate_dir_name
+
     # For Retrieval Evaluation
     train_datasets_config:
         enable_retrieve: False

--- a/src/models/uniir_clip/clip_scorefusion/configs_scripts/large/eval/inbatch/retrieval.yaml
+++ b/src/models/uniir_clip/clip_scorefusion/configs_scripts/large/eval/inbatch/retrieval.yaml
@@ -18,6 +18,7 @@ retrieval_config:
 
     # For using retrieved candidates in downstream applications like RAG.
     raw_retrieval: False # Store raw queries and their retrieved candidates
+    retrieve_image_text_pairs: False # During raw retrieval always retrieve imge-text pairs.
     query_dir_name: # Raw queries will be loaded from mbeir_data_dir/query_dir_name
     candidate_dir_name: # Raw retrieved candidates will be loaded from mbeir_data_dir/cand_pool/candidate_dir_name
 

--- a/src/models/uniir_clip/clip_scorefusion/configs_scripts/large/eval/inbatch/retrieval.yaml
+++ b/src/models/uniir_clip/clip_scorefusion/configs_scripts/large/eval/inbatch/retrieval.yaml
@@ -16,6 +16,11 @@ retrieval_config:
 
     write_to_tsv: True  # Write the results to csv files
 
+    # For using retrieved candidates in downstream applications like RAG.
+    raw_retrieval: False # Store raw queries and their retrieved candidates
+    query_dir_name: # Raw queries will be loaded from mbeir_data_dir/query_dir_name
+    candidate_dir_name: # Raw retrieved candidates will be loaded from mbeir_data_dir/cand_pool/candidate_dir_name
+
     # For Retrieval Evaluation
     train_datasets_config:
         enable_retrieve: False


### PR DESCRIPTION
[1/3] retrieve image-text pairs using interactive raw retrieval
This cl add a boolean `raw_retrieval` config that when enabled, the retriever stores the raw query and retrieved candidates in a jsonl format which will be later on useful for RAG applications of UniIR. Without this change the retriever only outputs runfiles in trec eval format.

Adding an interactive retriever to be able retrieve complement results for candidates, and complement retrieving will be followed in next cls.